### PR TITLE
Made minimum departure delay time configurable

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,6 +53,7 @@ dependencies {
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     testImplementation 'com.willowtreeapps.assertk:assertk:0.9'
+    testImplementation 'org.mockito:mockito-core:2.23.4'
 
     // http://loopj.com/android-async-http/
     implementation 'com.loopj.android:android-async-http:1.4.9'

--- a/app/src/main/java/com/geuso/disrupty/disruption/DisruptionEvaluator.kt
+++ b/app/src/main/java/com/geuso/disrupty/disruption/DisruptionEvaluator.kt
@@ -20,8 +20,8 @@ class DisruptionEvaluator(
     private val minimumDelayInMs: Int
 
     init {
-        // For whatever reason sharedPreferences.getInt is unable to return an Integer,
-        // so we need to get the String value and cast it...
+        // For whatever reason sharedPreferences.getInt throws a ClassCastException,
+        // so we need to get the String value and manually convert it...
         val minimumDelayInMinutes = Integer.parseInt(sharedPreferences.getString("pref_disruption_minimum_delay_time",
                 context.resources.getInteger(R.integer.default_delay_disruption_window_in_minutes).toString()))
 

--- a/app/src/main/java/com/geuso/disrupty/disruption/DisruptionEvaluator.kt
+++ b/app/src/main/java/com/geuso/disrupty/disruption/DisruptionEvaluator.kt
@@ -20,8 +20,10 @@ class DisruptionEvaluator(
     private val minimumDelayInMs: Int
 
     init {
-        val minimumDelayInMinutes = sharedPreferences.getInt("pref_disruption_minimum_delay_time",
-                context.resources.getInteger(R.integer.default_delay_disruption_window_in_minutes))
+        // For whatever reason sharedPreferences.getInt is unable to return an Integer,
+        // so we need to get the String value and cast it...
+        val minimumDelayInMinutes = Integer.parseInt(sharedPreferences.getString("pref_disruption_minimum_delay_time",
+                context.resources.getInteger(R.integer.default_delay_disruption_window_in_minutes).toString()))
 
         minimumDelayInMs = minimumDelayInMinutes * 60_000 // 1 minute = 60.000 ms
     }

--- a/app/src/main/java/com/geuso/disrupty/disruption/DisruptionService.kt
+++ b/app/src/main/java/com/geuso/disrupty/disruption/DisruptionService.kt
@@ -2,6 +2,7 @@ package com.geuso.disrupty.disruption
 
 import android.content.Context
 import android.net.ConnectivityManager
+import android.preference.PreferenceManager
 import android.util.Log
 import com.geuso.disrupty.R
 import com.geuso.disrupty.db.AppDatabase
@@ -61,7 +62,9 @@ class DisruptionService(val context: Context) {
                 override fun onSuccess(statusCode: Int, headers: Array<out Header>?, responseBody: String?) {
                     val travelOptions = TravelOptionXmlParser().parse(responseBody!!.byteInputStream())
 
-                    val disruptionCheckResult = DisruptionEvaluator.getDisruptionCheckResultFromTravelOptions(travelOptions)
+
+                    val disruptionEvaluator = DisruptionEvaluator(context, PreferenceManager.getDefaultSharedPreferences(context))
+                    val disruptionCheckResult = disruptionEvaluator.getDisruptionCheckResultFromTravelOptions(travelOptions)
 
                     val isDisrupted = disruptionCheckResult.isDisrupted
                     val disruptionMessage =  resolveDisruptionMessage(disruptionCheckResult)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,6 +53,12 @@
     <string name="pref_api_pass_not_set">Not setup</string>
     <string name="pref_api_pass_set">Set!</string>
 
+    <!-- Category Disruption configuration properties-->
+    <string name="pref_cat_disruption">Disruption configuration</string>
+    <string name="pref_disruption_delay_window_title">Acceptable departure delay</string>
+    <string name="pref_disruption_delay_window_summary">Minimum number of minutes before a delayed departure time is considered disrupted: %s minutes.</string>
+    <integer name="default_delay_disruption_window_in_minutes">3</integer>
+
     <!-- Disruption check log -->
     <string name="trigger_check">Trigger disruption check</string>
 

--- a/app/src/main/res/xml/settings.xml
+++ b/app/src/main/res/xml/settings.xml
@@ -22,4 +22,19 @@
 
     </PreferenceCategory>
 
+    <PreferenceCategory
+        android:key="settings_category_disruption_properties"
+        android:title="@string/pref_cat_disruption"
+        android:persistent="false">
+
+        <com.geuso.disrupty.settings.FormattedSummaryEditTextPreference
+            android:key="pref_disruption_minimum_delay_time"
+            android:title="@string/pref_disruption_delay_window_title"
+            android:summary="@string/pref_disruption_delay_window_summary"
+            android:inputType="number"
+            android:defaultValue="@integer/default_delay_disruption_window_in_minutes"
+            />
+
+    </PreferenceCategory>
+
 </PreferenceScreen>

--- a/app/src/test/java/com/geuso/disrupty/disruption/DisruptionEvaluationStatusTest.kt
+++ b/app/src/test/java/com/geuso/disrupty/disruption/DisruptionEvaluationStatusTest.kt
@@ -1,5 +1,8 @@
 package com.geuso.disrupty.disruption
 
+import android.content.Context
+import android.content.SharedPreferences
+import android.content.res.Resources
 import assertk.assert
 import assertk.assertions.isEqualTo
 import com.geuso.disrupty.ns.traveloption.DisruptionStatus
@@ -7,6 +10,7 @@ import com.geuso.disrupty.ns.traveloption.TravelOption
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
+import org.mockito.Mockito
 
 @RunWith(Parameterized::class)
 class DisruptionEvaluationStatusTest(
@@ -26,13 +30,23 @@ class DisruptionEvaluationStatusTest(
                 arrayOf(DisruptionStatus.NOT_POSSIBLE, true),
                 arrayOf(DisruptionStatus.PLAN_CHANGED, false)
         )
+
+        private val sharedPreferences = Mockito.mock(SharedPreferences::class.java)
+        private val context = Mockito.mock(Context::class.java)
+
+        init {
+            Mockito.`when`(sharedPreferences.getInt(Mockito.eq("pref_disruption_minimum_delay_time"), Mockito.anyInt()))
+                    .thenReturn(2)
+            Mockito.`when`(context.resources)
+                    .thenReturn(Mockito.mock(Resources::class.java))
+        }
     }
 
     @Test
     fun `Assert DisruptionStatus disrupted or not based on status`() {
         println("Testing that DisruptionStatus $disruptionStatus is disrupted: $isDisrupted")
         val travelOption = TravelOption(null, 2, true, disruptionStatus)
-        val disruptionCheckResult = DisruptionEvaluator.getDisruptionCheckResultFromTravelOptions(listOf(travelOption))
+        val disruptionCheckResult = DisruptionEvaluator(context, sharedPreferences).getDisruptionCheckResultFromTravelOptions(listOf(travelOption))
 
         assert(disruptionCheckResult.isDisrupted, "DisruptionCheckResult isDisrupted").isEqualTo(isDisrupted)
     }


### PR DESCRIPTION
Added configuration that controls the minimum time before a delayed travel option is considered disrupted 