### PR TITLE
Disruption check details debug info

### DIFF
--- a/app/lint.xml
+++ b/app/lint.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <lint>
     <issue id="Autofill" severity="ignore"/>
+    <issue id="RtlHardcoded" severity="ignore"/>
 </lint>

--- a/app/src/main/res/layout/disruption_check_detail_result_view.xml
+++ b/app/src/main/res/layout/disruption_check_detail_result_view.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+
+    <View
+        android:id="@+id/dc_result_top_line"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@android:color/darker_gray" />
+
+    <ImageView
+        android:id="@+id/imageView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:layout_marginTop="16dp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/dc_result_top_line"
+        app:srcCompat="@drawable/ic_subscription_status_unkown" />
+
+    <android.support.constraint.Guideline
+        android:id="@+id/guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_begin="28dp" />
+
+    <TextView
+        android:id="@+id/textView2"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginBottom="4dp"
+        android:text="Very important message"
+        app:layout_constraintBottom_toTopOf="@+id/guideline"
+        app:layout_constraintStart_toEndOf="@+id/imageView" />
+
+    <TextView
+        android:id="@+id/textView3"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="4dp"
+        android:text="+3 minuten"
+        app:layout_constraintStart_toEndOf="@+id/imageView"
+        app:layout_constraintTop_toTopOf="@+id/guideline" />
+
+    <TextView
+        android:id="@+id/textView4"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
+        android:text="Status goes here"
+        app:layout_constraintBottom_toTopOf="@+id/guideline"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/guideline" />
+
+    <View
+        android:id="@+id/dc_result_bottom_line"
+        android:layout_width="368dp"
+        android:layout_height="1dp"
+        android:layout_marginTop="4dp"
+        android:background="@android:color/darker_gray"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.0"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/textView3" />
+
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/disruption_check_detail_result_view.xml
+++ b/app/src/main/res/layout/disruption_check_detail_result_view.xml
@@ -13,7 +13,8 @@
         android:background="@android:color/darker_gray" />
 
     <ImageView
-        android:id="@+id/imageView"
+        android:id="@+id/dc_result_status_icon"
+        android:contentDescription="@string/disruption_check_status_indicator"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
@@ -23,42 +24,39 @@
         app:srcCompat="@drawable/ic_subscription_status_unkown" />
 
     <android.support.constraint.Guideline
-        android:id="@+id/guideline"
+        android:id="@+id/dc_result_guideline"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         app:layout_constraintGuide_begin="28dp" />
 
     <TextView
-        android:id="@+id/textView2"
+        android:id="@+id/dc_result_message"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginBottom="4dp"
-        android:text="Very important message"
-        app:layout_constraintBottom_toTopOf="@+id/guideline"
-        app:layout_constraintStart_toEndOf="@+id/imageView" />
+        app:layout_constraintBottom_toTopOf="@+id/dc_result_guideline"
+        app:layout_constraintStart_toEndOf="@+id/dc_result_status_icon" />
 
     <TextView
-        android:id="@+id/textView3"
+        android:id="@+id/dc_result_departure_delay"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="16dp"
         android:layout_marginTop="4dp"
-        android:text="+3 minuten"
-        app:layout_constraintStart_toEndOf="@+id/imageView"
-        app:layout_constraintTop_toTopOf="@+id/guideline" />
+        app:layout_constraintStart_toEndOf="@+id/dc_result_status_icon"
+        app:layout_constraintTop_toTopOf="@+id/dc_result_guideline" />
 
     <TextView
-        android:id="@+id/textView4"
+        android:id="@+id/dc_result_travel_option_status"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="8dp"
         android:layout_marginEnd="16dp"
-        android:text="Status goes here"
-        app:layout_constraintBottom_toTopOf="@+id/guideline"
+        app:layout_constraintBottom_toTopOf="@+id/dc_result_guideline"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/guideline" />
+        app:layout_constraintTop_toTopOf="@+id/dc_result_guideline" />
 
     <View
         android:id="@+id/dc_result_bottom_line"
@@ -70,7 +68,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/textView3" />
+        app:layout_constraintTop_toBottomOf="@+id/dc_result_departure_delay" />
 
 
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/disruption_check_detail_view.xml
+++ b/app/src/main/res/layout/disruption_check_detail_view.xml
@@ -48,18 +48,29 @@
         app:layout_constraintStart_toEndOf="@+id/dc_detail_timestamp"
         app:layout_constraintTop_toTopOf="@+id/dc_detail_timestamp" />
 
+    <include
+        android:id="@+id/dc_result_layout"
+        layout="@layout/disruption_check_detail_result_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/dc_detail_status" />
+
     <ScrollView
+        android:id="@+id/dc_scrollview_response"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:layout_marginBottom="8dp"
-        android:layout_marginEnd="16dp"
         android:layout_marginStart="16dp"
         android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="8dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.0"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/dc_detail_timestamp"
+        app:layout_constraintTop_toBottomOf="@id/dc_result_layout"
         app:layout_constraintVertical_bias="1.0">
 
         <TextView

--- a/app/src/main/res/layout/subscription_list_row.xml
+++ b/app/src/main/res/layout/subscription_list_row.xml
@@ -75,13 +75,12 @@
         android:id="@+id/sub_row_status_icon"
         android:layout_width="26dp"
         android:layout_height="26dp"
-        android:layout_marginEnd="16dp"
-        android:layout_marginStart="8dp"
         android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp"
         android:contentDescription="@string/subscription_row_status_description"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.79"
-        app:layout_constraintStart_toEndOf="@+id/sub_row_station_to"
         app:layout_constraintTop_toTopOf="parent"
         app:srcCompat="@drawable/ic_subscription_status_unkown" />
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -10,4 +10,6 @@
     <color name="ic_status_not_ok">#e74a38</color>
     <color name="ic_status_unknown">#a6a49b</color>
 
+    <color name="text_grayed_out">#c1c1bc</color>
+
 </resources>

--- a/app/src/main/res/values/values_disruptions.xml
+++ b/app/src/main/res/values/values_disruptions.xml
@@ -14,6 +14,15 @@
 
     <string name="disruption_check_detail_missing_id">Unable to load disruption check details for empty disruption check id</string>
 
+    <!-- Detail view -->
+    <string name="disruption_check_result_message">Message: %1$s</string>
+    <string name="disruption_check_result_delay">Delay: %1$s</string>
+
+    <string name="disruption_check_default_result_message">no message</string>
+    <string name="disruption_check_default_result_delay">no delay</string>
+
+    <string name="disruption_check_status_indicator">Status indicator of this disruption check</string>
+
     <!-- Disruption checks -->
     <string name="disruption_check_no_network">No network connectivity, unable to check disruptions.</string>
 


### PR DESCRIPTION
Adds the result of an disruption check evaluation to the disruption check detail view. Serves as a quick summary so that it's not necessary to read the xml response.